### PR TITLE
Fake SD

### DIFF
--- a/ducky_interpreter/fakesd.cpp
+++ b/ducky_interpreter/fakesd.cpp
@@ -1,0 +1,32 @@
+#include "fakesd.h"
+#include "string.h"
+Fakesd::Fakesd(){
+  //Aqui se puede hardcodear la string
+  strcpy(scriptraw,"DELAY 3000\nGUI\nDELAY 1500\nSTRING terminal\nDELAY 1500\nENTER\nDELAY 1000\nSTRING echo Hello World!!!\nENTER");
+  read_position = 0;
+}
+char Fakesd::read() {
+  char ret = scriptraw[read_position];
+  read_position++;
+  return ret;
+}
+
+bool Fakesd::available(){
+  char current = scriptraw[read_position];
+  if(current == '\0'){
+    return false;
+  }
+  return true;
+}
+
+unsigned long Fakesd::position(){
+  return read_position;
+}
+
+bool Fakesd::seek(unsigned long new_position){
+  read_position = new_position;
+  return true;
+}
+
+void Fakesd::close(){
+}

--- a/ducky_interpreter/fakesd.h
+++ b/ducky_interpreter/fakesd.h
@@ -1,0 +1,15 @@
+#define Fakesd_d
+
+
+class Fakesd{
+  private:
+    char scriptraw[400];
+    unsigned long read_position;
+  public:
+    Fakesd();
+    char read();
+    bool available();
+    unsigned long position();
+    bool seek(unsigned long new_position);
+    void close();
+};


### PR DESCRIPTION
Dandole vueltas al funcionamiento de vuestro interprete de rubber ducky, tuve una idea.
¿porque no utilizar la memoria sobrante para utilizar la memoria restante en el arduino para guardar el script de rubber ducky?
Así que me he puesto a hacer una clase que puede substituir a la sd pero escribiendo directamente sobre la memoria de arduino. Evidentemente de esta forma dispones de menos espacio y es mas facil que se quede sin memoria el arduino, pero he estado realizando pruebas y ha funcionado.
Bueno si os mola el codigo es vuestro para incluirlo.
Disculpad si el codigo no esta muy bien escrito, era mi primera vez con C++